### PR TITLE
Fix Nested FBX Node and Add Apply Transform Option

### DIFF
--- a/Packages/com.triturbo.blendshare/Editor/BlendShapeData/BlendShapeAppender.cs
+++ b/Packages/com.triturbo.blendshare/Editor/BlendShapeData/BlendShapeAppender.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 using UnityEditor;
 #if ENABLE_FBX_SDK
+using Triturbo.BlendShapeShare.Util.Fbx;
 using Autodesk.Fbx;
 #endif
 
@@ -277,10 +278,7 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
         //Add TargetShape to FbxBlendShapeChannel from FbxBlendShapeData
         public static FbxBlendShapeChannel CreateFbxBlendShapeChannel(FbxBlendShapeChannel fbxBlendShapeChannel, FbxMesh mesh, FbxBlendShapeData fbxBlendShapeData)
         {
-
             int controlPointCount = mesh.GetControlPointsCount();
-           
-
             int shapeCount = fbxBlendShapeData.m_Frames.Length;
             for (int shapeIndex = 0; shapeIndex < shapeCount; shapeIndex++)
             {
@@ -289,20 +287,14 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
                 newShape.InitControlPoints(controlPointCount);
 
                 FbxBlendShapeFrame frame = fbxBlendShapeData.m_Frames[shapeIndex];
-
-
+                
                 for (int pointIndex = 0; pointIndex < controlPointCount; pointIndex++)
                 {
                     var d = frame.GetDeltaControlPointAt(pointIndex);
-
                     var controlPoint = mesh.GetControlPointAt(pointIndex) + new FbxVector4(d.m_X, d.m_Y, d.m_Z, d.m_W);
-
-
-
                     newShape.SetControlPointAt(controlPoint, pointIndex);
                 }
-
-
+                
                 fbxBlendShapeChannel.AddTargetShape(newShape, 100.0 * (shapeIndex + 1) / shapeCount);
             }
             return fbxBlendShapeChannel;
@@ -378,6 +370,7 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
                 }
             }
         }
+        
 #endif
         public static bool CreateFbx(this BlendShapeDataSO so, string outputPath = null)
         {
@@ -426,7 +419,7 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
 
             foreach (var meshData in so.m_MeshDataList)
             {
-                FbxNode node = sourceRootNode.FindChild(meshData.m_MeshName, false);
+                FbxNode node = sourceRootNode.FindMeshChild(meshData.m_MeshName);
                 FbxMesh targetMesh = node?.GetMesh();
                 if (targetMesh == null)
                 {

--- a/Packages/com.triturbo.blendshare/Editor/BlendShapeData/Inspector/BlendShapeDataSOEditor.cs
+++ b/Packages/com.triturbo.blendshare/Editor/BlendShapeData/Inspector/BlendShapeDataSOEditor.cs
@@ -18,7 +18,8 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
         private SerializedProperty appliedProperty;
 
         private bool readOnlyMode = true;
-
+        
+        [SerializeField]
         private Texture bannerIcon;
 
         private List<List<SerializedProperty>> meshBlendShapeNames;
@@ -36,20 +37,14 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
         }
         private void OnEnable()
         {
-            
             meshDataListProperty = serializedObject.FindProperty(nameof(BlendShapeDataSO.m_MeshDataList));
             originalFbxProperty = serializedObject.FindProperty(nameof(BlendShapeDataSO.m_Original));
             appliedProperty = serializedObject.FindProperty(nameof(BlendShapeDataSO.m_Applied));
-
-            bannerIcon = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath("6ee731e02404e154694005c2442f2bf4"), typeof(Texture)) as Texture;
             meshBlendShapeNames = new List<List<SerializedProperty>>();
-            
             // Get the target object
             BlendShapeDataSO dataAsset = (BlendShapeDataSO)target;
 
             meshBlendShapes = new List<ReorderableList>(dataAsset.m_MeshDataList.Count);
-
-
             for (int i = 0; i < meshDataListProperty.arraySize; i++)
             {
                 var meshDataProperty = meshDataListProperty.GetArrayElementAtIndex(i);
@@ -79,28 +74,18 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
 
         public override void OnInspectorGUI()
         {
-            if (bannerIcon != null)
-            {
-                GUILayout.BeginHorizontal();
-                GUILayout.FlexibleSpace(); // Pushes the label to the center
-                GUILayout.Label(bannerIcon, GUILayout.Height(42), GUILayout.Width(168));
 
-
-                GUILayout.FlexibleSpace(); // Pushes the label to the center
-                GUILayout.EndHorizontal();
-                GUILayout.Space(8);
-            }
-
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace(); // Pushes the label to the center
+            GUILayout.Label(bannerIcon, GUILayout.Height(42), GUILayout.Width(168));
+            GUILayout.FlexibleSpace(); // Pushes the label to the center
+            GUILayout.EndHorizontal();
+            GUILayout.Space(8);
+ 
             EditorGUI.BeginDisabledGroup(readOnlyMode);
             EditorGUILayout.PropertyField(originalFbxProperty);
-
-
-
             EditorGUI.EndDisabledGroup();
-
-
-
-
+            
             for (int i = 0; i < meshDataListProperty.arraySize; i++)
             {
                 SerializedProperty meshDataProperty =
@@ -112,18 +97,12 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
 
                 SerializedProperty meshProperty =
                     meshDataProperty.FindPropertyRelative(nameof(MeshData.m_OriginMesh));
-
-
-
+                
                 EditorGUILayout.BeginVertical(GUI.skin.box);
-
                 EditorGUI.BeginDisabledGroup(readOnlyMode);
-
-
+                
                 if (originalFbxProperty.serializedObject.hasModifiedProperties)
                 {
-
-                    
                     var meshName = meshNameProperty.stringValue;
                     var node = (originalFbxProperty.objectReferenceValue as GameObject)?.transform.Find(meshName);
 
@@ -133,7 +112,6 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
                     {
                         meshProperty.objectReferenceValue = meshRenderer.sharedMesh;
                     }
-
                 }
 
                 EditorGUILayout.ObjectField(meshProperty, new GUIContent(meshNameProperty.stringValue));

--- a/Packages/com.triturbo.blendshare/Editor/BlendShapeData/Inspector/BlendShapeDataSOEditor.cs.meta
+++ b/Packages/com.triturbo.blendshare/Editor/BlendShapeData/Inspector/BlendShapeDataSOEditor.cs.meta
@@ -3,7 +3,8 @@ guid: ebaac7be47257634faf377a7b1d0577e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - bannerIcon: {fileID: 2800000, guid: 6ee731e02404e154694005c2442f2bf4, type: 3}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/Packages/com.triturbo.blendshare/Editor/BlendShapeData/Triturbo.BlendShapeShare.Data.asmdef
+++ b/Packages/com.triturbo.blendshare/Editor/BlendShapeData/Triturbo.BlendShapeShare.Data.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "Triturbo.BlendShapeShare.Data.Editor",
+    "rootNamespace": "",
     "references": [
-        "GUID:2b82e46c4ca0a4eb697ab8ccdfb39af1"
+        "GUID:2b82e46c4ca0a4eb697ab8ccdfb39af1",
+        "GUID:310e50e946a3d3f47a2b344b62f35a08"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractor.cs
+++ b/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractor.cs
@@ -12,13 +12,41 @@ using System.Threading.Tasks;
 
 #if ENABLE_FBX_SDK
 using Autodesk.Fbx;
+using Triturbo.BlendShapeShare.Util.Fbx;
 # endif
+
+
 namespace Triturbo.BlendShapeShare.Extractor
 {
+    public class BlendShapesExtractorOptions
+    {
+        public enum BaseMesh
+        {
+            Source,
+            Original
+        }
+
+        public BaseMesh baseMesh = BaseMesh.Source;
+        public bool weldVertices = true;
+        public bool applyRotation = false;
+        public bool applyScale = false;
+        public bool applyTranslate = false;
+        public double blendShapesScale = 1;
+
+        public bool ApplyTransform
+        {
+            get
+            {
+                
+                return applyRotation || applyScale || applyTranslate;
+            }
+        }
+    }
+
     public static class BlendShapesExtractor
     {
-        public static BlendShapeDataSO ExtractBlendShapes(GameObject blendShapeSource, GameObject originObject, List<MeshData> meshDataList, 
-            bool sourceAsBaseMesh = true, bool fixWeldVertices = true)
+        public static BlendShapeDataSO ExtractBlendShapes(GameObject blendShapeSource, GameObject originObject, List<MeshData> meshDataList,
+           BlendShapesExtractorOptions blendShapesExtractorOptions)
         {
             var data = ScriptableObject.CreateInstance<BlendShapeDataSO>();
 
@@ -26,29 +54,35 @@ namespace Triturbo.BlendShapeShare.Extractor
 
             string defaultName = $"{originObject.name}-{blendShapeSource.name}";
 
-#if ENABLE_FBX_SDK
-            if (IsUnityVerticesEqual(blendShapeSource, originObject))
-            {
+            bool sourceAsBaseMesh = blendShapesExtractorOptions.baseMesh == BlendShapesExtractorOptions.BaseMesh.Source;
 
-                if (!ExtractFbxBlendshapes(ref meshDataList, blendShapeSource, weldVertices: false, sourceAsBaseMesh: sourceAsBaseMesh))
+#if ENABLE_FBX_SDK
+            if (IsUnityVerticesEqual(blendShapeSource, originObject) && !blendShapesExtractorOptions.ApplyTransform)
+            {
+                if (!ExtractFbxBlendshapes(ref meshDataList, blendShapeSource, blendShapesExtractorOptions))
                 {
+                    Debug.Log("ExtractFbxBlendshapes failed");
                     return null;
                 }
                 ExtractUnityBlendShapes(ref meshDataList, blendShapeSource, sourceAsBaseMesh ? blendShapeSource : originObject);
             }
             else
             {
+                Debug.LogWarning("Unity Vertices Not Equal");
+
                 string path = AssetDatabase.GetAssetPath(originObject);
                 string tmp = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(path), $"{originObject.name}-{blendShapeSource.name}-{System.Guid.NewGuid().ToString()}.fbx");
 
                 AssetDatabase.CopyAsset(path, tmp);
                 AssetDatabase.Refresh();
 
-                if (!ExtractFbxBlendshapes(ref meshDataList, blendShapeSource, originObject, tmp, fixWeldVertices, sourceAsBaseMesh))
+                
+                if (!ExtractFbxBlendshapes(ref meshDataList, blendShapeSource, blendShapesExtractorOptions, originObject, tmp))
                 {
                     AssetDatabase.DeleteAsset(tmp);
                     return null;
                 }
+
                 var genertated = AssetDatabase.LoadAssetAtPath<GameObject>(tmp);
 
                 if (IsUnityVerticesEqual(genertated, originObject))
@@ -86,27 +120,60 @@ namespace Triturbo.BlendShapeShare.Extractor
             return data;
         }
 
+        #region Path 
 
-
-#if ENABLE_FBX_SDK
+        /// <summary>
+        /// Recursively builds a dictionary mapping mesh names to their relative paths.
+        /// </summary>
+        private static void BuildMeshPathLookup(Dictionary<string, string> lookup, Transform current, string parentPath = null)
+        {
+            string currentPath = string.IsNullOrEmpty(parentPath) ? current.name : $"{parentPath}/{current.name}";
+            if (current.TryGetComponent(out SkinnedMeshRenderer meshRenderer))
+            {
+                if (meshRenderer.sharedMesh == null)
+                {
+                    Debug.LogError($"SharedMesh is null in {meshRenderer.name}");
+                }
+                if (!lookup.ContainsKey(meshRenderer.sharedMesh.name))
+                {
+                    lookup[meshRenderer.sharedMesh.name] = currentPath;
+                    Debug.Log($"LookUP:{meshRenderer.sharedMesh.name} - {currentPath}");
+                }
+            }
+            foreach (Transform child in current)
+            {
+                BuildMeshPathLookup(lookup, child, parentPath == null ? "" : currentPath);
+            }
+        }
         
-        public static bool ExtractFbxBlendshapes(
-            ref List<MeshData> meshDataList, GameObject source, GameObject origin = null, string exportPath = "", bool weldVertices = true, bool sourceAsBaseMesh = true)
+        private static string GetRelativePath(Transform target, Transform root)
+        {
+            if (target == root) return "";
+            return GetRelativePath(target.parent, root) + (target.parent == root ? "" : "/") + target.name;
+        }
+
+        #endregion
+       
+
+        #region FBX SDK
+
+        #if ENABLE_FBX_SDK
+        
+        public static bool ExtractFbxBlendshapes(ref List<MeshData> meshDataList, GameObject source, 
+            BlendShapesExtractorOptions blendShapesExtractorOptions, GameObject origin = null, string exportPath = "")
         {
             if (meshDataList == null)
             {
                 meshDataList = new List<MeshData>();
             }
-
+            
             var fbxManager = FbxManager.Create();
 
             var ios = FbxIOSettings.Create(fbxManager, Globals.IOSROOT);
             fbxManager.SetIOSettings(ios);
 
             var sourceScene = FbxScene.Create(fbxManager, "Source");
-
-
-
+            
             if (EditorUtility.DisplayCancelableProgressBar("Extract blendshapes", "Create FBX scene...", 0))
             {
                 EditorUtility.ClearProgressBar();
@@ -116,9 +183,7 @@ namespace Triturbo.BlendShapeShare.Extractor
 
             FbxImporter fbxImporter = FbxImporter.Create(fbxManager, "");
             int pFileFormat = fbxManager.GetIOPluginRegistry().FindWriterIDByDescription("FBX binary (*.fbx)");
-
-
-
+            
             if (EditorUtility.DisplayCancelableProgressBar("Extract blendshapes", "Import source FBX...", 0.1f))
             {
                 EditorUtility.ClearProgressBar();
@@ -131,8 +196,7 @@ namespace Triturbo.BlendShapeShare.Extractor
             }
             fbxImporter.Import(sourceScene);
             fbxImporter.Destroy();
-
-
+            
             FbxScene originScene = null;
             FbxManager originFbxManager = null;
 
@@ -158,8 +222,7 @@ namespace Triturbo.BlendShapeShare.Extractor
                 originFbxImporter.Destroy();
             }
 
-
-
+            
             if (EditorUtility.DisplayCancelableProgressBar("Extract blendshapes", "Get Root Node...", 0.4f))
             {
                 EditorUtility.ClearProgressBar();
@@ -171,34 +234,58 @@ namespace Triturbo.BlendShapeShare.Extractor
             int count = 0;
             foreach (var meshData in meshDataList)
             {
-                FbxNode node = sourceRootNode.FindChild(meshData.m_MeshName, false);
+                //FbxNode node = sourceRootNode.FindChildByPath(meshPathLookup.GetValueOrDefault(meshData.m_MeshName));
+                FbxNode node = sourceRootNode.FindMeshChild(meshData.m_MeshName);
                 FbxMesh sourceMesh = node?.GetMesh();
-
-
                 if (EditorUtility.DisplayCancelableProgressBar("Extract blendshapes", $"Check node: {meshData.m_MeshName}", 0.4f + 0.4f * count++ / meshDataList.Count))
                 {
                     EditorUtility.ClearProgressBar();
                     return false;
                 }
-
                 if (sourceMesh == null)
                 {
                     Debug.LogError($"Can not find mesh: {meshData.m_MeshName} in FBX file");
                     continue;
                 }
-
                 if (sourceMesh.GetDeformerCount(FbxDeformer.EDeformerType.eBlendShape) < 1)
                 {
                     continue;
                 }
-
-
-                FbxNode nodeOrigin = originRootNode?.FindChild(meshData.m_MeshName, false);
+                //FbxNode nodeOrigin = originRootNode?.FindChildByPath(meshPathLookup.GetValueOrDefault(meshData.m_MeshName));
+                FbxNode nodeOrigin = originRootNode?.FindMeshChild(meshData.m_MeshName);
                 FbxMesh originMesh = nodeOrigin?.GetMesh();
+                FbxAMatrix relativeTransform;
+                if (blendShapesExtractorOptions.ApplyTransform)
+                {
+                    FbxAMatrix sourceMatrix = node.EvaluateLocalTransform();
+                    FbxAMatrix originalMatrix = nodeOrigin.EvaluateLocalTransform();
 
+                    relativeTransform = sourceMatrix * originalMatrix.Inverse();
+
+                    sourceMatrix.Dispose();
+                    originalMatrix.Dispose();
+
+                    if (!blendShapesExtractorOptions.applyScale)
+                    {
+                        relativeTransform.SetS(new FbxVector4(1, 1, 1, 1));
+                    }
+                    if (!blendShapesExtractorOptions.applyRotation)
+                    {
+                        relativeTransform.SetR(new FbxVector4(0, 0, 0, 0));
+                    }
+                    if (!blendShapesExtractorOptions.applyTranslate)
+                    {
+                        relativeTransform.SetT(new FbxVector4(0, 0, 0, 0));
+                    }
+                }
+                else
+                {
+                    relativeTransform = new FbxAMatrix();
+                    relativeTransform.SetIdentity();
+                }
                 
                 //Remove all blendshapes in original mesh and make it a container as new blendshapes.
-                if (originMesh != null && !weldVertices)
+                if (originMesh != null && !blendShapesExtractorOptions.weldVertices)
                 {
                     for (int dIndex = 0; dIndex < originMesh.GetDeformerCount(FbxDeformer.EDeformerType.eBlendShape); dIndex++)
                     {
@@ -208,11 +295,11 @@ namespace Triturbo.BlendShapeShare.Extractor
 
                 FbxBlendShape originDeformer = originMesh != null ? FbxBlendShape.Create(originMesh, "BlendShapeShareTemp") : null;
 
+
+                bool sourceAsBaseMesh = blendShapesExtractorOptions.baseMesh == BlendShapesExtractorOptions.BaseMesh.Source;
                 var baseMesh = sourceAsBaseMesh ? sourceMesh : originMesh;
-
-
-
-                var weldingGroups = weldVertices ? GetWeldingGroups(originMesh) : null;
+                
+                var weldingGroups = blendShapesExtractorOptions.weldVertices && originMesh != null ? GetWeldingGroups(originMesh) : null;
 
                 for (int dIndex = 0; dIndex < sourceMesh.GetDeformerCount(FbxDeformer.EDeformerType.eBlendShape); dIndex++)
                 {
@@ -232,15 +319,13 @@ namespace Triturbo.BlendShapeShare.Extractor
 
                         if (originDeformer != null)
                         {
-                            originDeformer.AddBlendShapeChannel(CopyFbxBlendShapeChannel(channel, originMesh, baseMesh, weldingGroups));
+                            originDeformer.AddBlendShapeChannel(CopyFbxBlendShapeChannel(channel, originMesh, baseMesh, weldingGroups, relativeTransform));
                         }
-
-                        meshData.SetBlendShape(name, GetFbxBlendShapeData(channel, sourceMesh, weldingGroups, baseMesh));
-
-
+                        meshData.SetBlendShape(name, GetFbxBlendShapeData(channel, sourceMesh, weldingGroups, relativeTransform, baseMesh));
                     }
                 }
 
+                relativeTransform.Dispose();
             }
 
 
@@ -261,21 +346,14 @@ namespace Triturbo.BlendShapeShare.Extractor
                 exporter.Export(originScene);
                 exporter.Destroy();
             }
-
-
+            
             AssetDatabase.Refresh();
             EditorUtility.ClearProgressBar();
-
-
-
-
-
-
             return true;
         }
-
-
-        public static FbxBlendShapeChannel CopyFbxBlendShapeChannel(FbxBlendShapeChannel source, FbxMesh target, FbxMesh baseMesh, List<List<int>> weldingList)
+        
+        public static FbxBlendShapeChannel CopyFbxBlendShapeChannel(FbxBlendShapeChannel source, FbxMesh target, FbxMesh baseMesh, List<List<int>> weldingList,
+            FbxAMatrix transformMatrix)
         {
             //
             Stopwatch stopwatch = new Stopwatch();
@@ -312,19 +390,41 @@ namespace Triturbo.BlendShapeShare.Extractor
 
                 for (int pointIndex = 0; pointIndex < controlPointCount; pointIndex++)
                 {
-                    if(weldingList == null)
+                    var baseControlPoint = baseMesh.GetControlPointAt(pointIndex);
+
+
+                    if (weldingList == null)
                     {
-                        newShape.SetControlPointAt(source.GetTargetShape(shapeIndex).GetControlPointAt(pointIndex), pointIndex);
+                        FbxVector4 delta;
+
+                        if (baseMesh != target)
+                        {
+                            delta = transformMatrix.MultT(source.GetTargetShape(shapeIndex).GetControlPointAt(pointIndex) - baseControlPoint);
+                        }
+                        else
+                        {
+                            delta = transformMatrix.MultT(source.GetTargetShape(shapeIndex).GetControlPointAt(pointIndex)) - baseControlPoint;
+                        }
+
+                        FbxVector4 transformedPoint = target.GetControlPointAt(pointIndex) + delta;
+
+                        newShape.SetControlPointAt(transformedPoint, pointIndex);
 
                     }
                     else
                     {
-                        var cp = baseMesh.GetControlPointAt(pointIndex);
-                        deltas[pointIndex] = source.GetTargetShape(shapeIndex).GetControlPointAt(pointIndex) - cp;
+                        if (baseMesh != target)
+                        {
+                            deltas[pointIndex] = transformMatrix.MultT(source.GetTargetShape(shapeIndex).GetControlPointAt(pointIndex) - baseControlPoint);
+                        }
+                        else
+                        {
+                            deltas[pointIndex] = transformMatrix.MultT(source.GetTargetShape(shapeIndex).GetControlPointAt(pointIndex)) - baseControlPoint;
+                        }
                     }
                 }
 
-                if(weldingList != null)
+                if (weldingList != null)
                 {
                     foreach (var welding in weldingList)
                     {
@@ -346,7 +446,8 @@ namespace Triturbo.BlendShapeShare.Extractor
 
                     for (int i = 0; i < deltas.Length; i++)
                     {
-                        newShape.SetControlPointAt(target.GetControlPointAt(i) + deltas[i], i);
+                        FbxVector4 transformedPoint = target.GetControlPointAt(i) + deltas[i];
+                        newShape.SetControlPointAt(transformedPoint, i);
                     }
                 }
 
@@ -358,7 +459,6 @@ namespace Triturbo.BlendShapeShare.Extractor
 
             return fbxBlendShapeChannel;
         }
-
 
         public static List<FbxVector4>[] GetNormals(FbxMesh mesh)
         {
@@ -401,7 +501,7 @@ namespace Triturbo.BlendShapeShare.Extractor
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
             //
-
+            
             int count = mesh.GetControlPointsCount();
             Dictionary<FbxVector4, List<int>> controlPointPosition = new Dictionary<FbxVector4, List<int>>();
 
@@ -469,7 +569,8 @@ namespace Triturbo.BlendShapeShare.Extractor
 
         // Creates FbxBlendShapeData from a given FbxBlendShapeChannel and FbxMesh.
         // The base FbxMesh to use as a reference for computing blendshape offsets. If null, sourceMesh is used as the base.
-        public static FbxBlendShapeData GetFbxBlendShapeData(FbxBlendShapeChannel source, FbxMesh sourceMesh, List<List<int>> weldingGroup, FbxMesh baseMesh = null)
+        public static FbxBlendShapeData GetFbxBlendShapeData(FbxBlendShapeChannel source, FbxMesh sourceMesh, List<List<int>> weldingGroup,
+           FbxAMatrix transformMatrix, FbxMesh baseMesh = null)
         {
             int controlPointCount = sourceMesh.GetControlPointsCount();
 
@@ -507,7 +608,17 @@ namespace Triturbo.BlendShapeShare.Extractor
                 {
                     var shapeControlPoint = sourceShape.GetControlPointAt(pointIndex);
                     var basicControlPoint = baseMesh.GetControlPointAt(pointIndex);
-                    deltas[pointIndex] = shapeControlPoint - basicControlPoint;
+
+
+                    if (baseMesh == sourceMesh)
+                    {
+                        deltas[pointIndex] = transformMatrix.MultT(shapeControlPoint - basicControlPoint);
+                    }
+                    else
+                    {
+                        deltas[pointIndex] = transformMatrix.MultT(shapeControlPoint) - basicControlPoint;
+                    }
+                    
 
                     if (weldingGroup == null)
                     {
@@ -518,7 +629,7 @@ namespace Triturbo.BlendShapeShare.Extractor
                     }
                 }
 
-                if(weldingGroup != null)
+                if (weldingGroup != null)
                 {
                     foreach (var welding in weldingGroup)
                     {
@@ -551,68 +662,80 @@ namespace Triturbo.BlendShapeShare.Extractor
             return new FbxBlendShapeData(frames);
         }
 
+
 #endif
 
-        //Compare GameOjects and find out extra blendshape and store the names in each MeshData
+        #endregion
+
+
         public static List<MeshData> CompareBlendShape(GameObject source, GameObject origin, bool compareByName = true)
         {
             List<MeshData> meshDataList = new List<MeshData>();
-            var skinnedMeshRenderers = source.GetComponentsInChildren<SkinnedMeshRenderer>(true);
-            foreach (Transform tansform in source.transform)
+            Dictionary<string, SkinnedMeshRenderer> originMeshLookup = new Dictionary<string, SkinnedMeshRenderer>();
+
+            // Create a lookup dictionary for origin mesh renderers
+            foreach (var skinnedMesh in origin.GetComponentsInChildren<SkinnedMeshRenderer>(true))
             {
-                Mesh sourceMesh = tansform.TryGetComponent(out SkinnedMeshRenderer meshRenderer) ? meshRenderer.sharedMesh : null;
+                originMeshLookup[skinnedMesh.name] = skinnedMesh;
+            }
+
+            foreach (var meshRenderer in source.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+            {
+                Mesh sourceMesh = meshRenderer.sharedMesh;
                 if (sourceMesh == null)
                 {
                     continue;
                 }
-                Mesh originMesh = origin.transform.Find(tansform.name)?.GetComponent<SkinnedMeshRenderer>()?.sharedMesh;
 
-                if (originMesh == null)
+                // Use lookup dictionary for faster search
+                if (!originMeshLookup.TryGetValue(meshRenderer.name, out SkinnedMeshRenderer originRenderer) || originRenderer.sharedMesh == null)
                 {
-                    Debug.LogError($"Can not find {tansform.name} in origin: {origin.name}");
+                    Debug.LogError($"Cannot find matching SkinnedMeshRenderer for {meshRenderer.name} in origin: {origin.name}");
                     continue;
                 }
 
+                Mesh originMesh = originRenderer.sharedMesh;
+                List<string> extraBlendShapes;
+
                 if (compareByName)
                 {
-                    MeshData meshData = new MeshData(originMesh, GetExtraBlendShapeNames(sourceMesh, originMesh));
-                    meshDataList.Add(meshData);
+                    extraBlendShapes = GetExtraBlendShapeNames(sourceMesh, originMesh);
                 }
                 else
                 {
-                    List<string> blendShapes = new List<string>();
+                    extraBlendShapes = new List<string>();
                     for (int i = originMesh.blendShapeCount; i < sourceMesh.blendShapeCount; i++)
                     {
-                        blendShapes.Add(sourceMesh.GetBlendShapeName(i));
-
-                   
+                        extraBlendShapes.Add(sourceMesh.GetBlendShapeName(i));
                     }
-                    MeshData meshData = new MeshData(originMesh, blendShapes);
-
-                    meshDataList.Add(meshData);
                 }
 
-               
+                MeshData meshData = new MeshData(originMesh, extraBlendShapes);
+                meshDataList.Add(meshData);
             }
             return meshDataList;
         }
 
 
-
-
+        
+        #region Unity Mesh
+        
         public static bool IsUnityVerticesEqual(GameObject source, GameObject origin)
         {
-            foreach (Transform tansform in source.transform)
+            foreach (Transform transform in source.transform)
             {
-                Mesh sourceMesh = tansform.TryGetComponent(out SkinnedMeshRenderer meshRenderer) ? meshRenderer.sharedMesh : null;
+                Mesh sourceMesh = transform.TryGetComponent(out SkinnedMeshRenderer meshRenderer) ? meshRenderer.sharedMesh : null;
                 if (sourceMesh == null)
                 {
                     continue;
                 }
-                Mesh originMesh = origin.transform.Find(tansform.name)?.GetComponent<SkinnedMeshRenderer>()?.sharedMesh;
+                
+                string relativePath = GetRelativePath(transform, source.transform);
+
+                Mesh originMesh = origin.transform.Find(relativePath)?.GetComponent<SkinnedMeshRenderer>()?.sharedMesh;
                 if (originMesh == null)
                 {
-                    Debug.LogError($"Can not find {tansform.name} in origin: {origin.name}");
+                    Debug.LogError($"Can not find {transform.name} in origin: {origin.name}");
                     return false;
                 }
 
@@ -630,42 +753,51 @@ namespace Triturbo.BlendShapeShare.Extractor
 
             return true;
         }
-
-        //unity
         public static void ExtractUnityBlendShapes(ref List<MeshData> meshDataList, GameObject source, GameObject baseObject)
         {
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
-            foreach (Transform tansform in source.transform)
+
+            // Convert meshDataList to a dictionary for faster lookup
+            Dictionary<string, MeshData> meshDataDict = meshDataList.ToDictionary(m => m.m_MeshName);
+
+            // Get all skinned mesh renderers in source
+            var skinnedMeshRenderers = source.GetComponentsInChildren<SkinnedMeshRenderer>(true);
+
+            foreach (var meshRenderer in skinnedMeshRenderers)
             {
-                Mesh sourceMesh = tansform.TryGetComponent(out SkinnedMeshRenderer meshRenderer) ? meshRenderer.sharedMesh : null;
+                Mesh sourceMesh = meshRenderer.sharedMesh;
                 if (sourceMesh == null)
                 {
                     continue;
                 }
 
-                MeshData meshData = meshDataList.SingleOrDefault(m => m.m_MeshName == tansform.name);
-               
-                if (meshData == null)
+                // Look up MeshData by name
+                if (!meshDataDict.TryGetValue(sourceMesh.name, out MeshData meshData))
                 {
                     continue;
                 }
 
                 Mesh baseMesh = null;
-                if(source == baseObject)
+                if (source == baseObject)
                 {
                     baseMesh = sourceMesh;
                 }
                 else if (baseObject != null)
                 {
-                    Transform baseMeshTransform = baseObject.transform.Find(tansform.name);
-                    if(baseMeshTransform != null)
+                    // Get relative path and find the corresponding mesh in baseObject
+                    string relativePath = GetRelativePath(meshRenderer.transform, source.transform);
+                    Transform baseMeshTransform = baseObject.transform.Find(relativePath);
+                
+                    if (baseMeshTransform != null && baseMeshTransform.TryGetComponent(out SkinnedMeshRenderer baseMeshRenderer))
                     {
-                        baseMesh = baseMeshTransform.TryGetComponent(out SkinnedMeshRenderer baseMeshRenderer) ? baseMeshRenderer.sharedMesh : null;
+                        baseMesh = baseMeshRenderer.sharedMesh;
                     }
                 }
+
                 meshData.ExtractUnityBlendShapes(sourceMesh, baseMesh);
             }
+
             stopwatch.Stop();
             Debug.Log("Extract Unity BlendShapes Time taken: " + stopwatch.ElapsedMilliseconds + " ms");
         }
@@ -759,6 +891,9 @@ namespace Triturbo.BlendShapeShare.Extractor
             }
 
         }
+
+        #endregion
+        
 
     }
 

--- a/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractorEditor.cs
+++ b/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractorEditor.cs
@@ -13,7 +13,7 @@ namespace Triturbo.BlendShapeShare.Extractor
         public GameObject sourceFBX;
 
         public string defaultName = "";
-        public static Texture bannerIcon;
+        public Texture bannerIcon;
 
         public enum CompareMethod
         {
@@ -53,7 +53,6 @@ namespace Triturbo.BlendShapeShare.Extractor
         public static void ShowWindow()
         {
             GetWindow<BlendShapesExtractorEditor>("BlendShare");
-            bannerIcon = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath("6ee731e02404e154694005c2442f2bf4"), typeof(Texture)) as Texture;
         }
         bool IsFBXFile(GameObject obj)
         {
@@ -66,40 +65,26 @@ namespace Triturbo.BlendShapeShare.Extractor
 
         private void OnGUI()
         {
-
-            if (bannerIcon != null)
-            {
-                GUILayout.BeginHorizontal();
-                GUILayout.FlexibleSpace(); // Pushes the label to the center
-                GUILayout.Label(bannerIcon, GUILayout.Height(42), GUILayout.Width(168));
-
-                GUILayout.FlexibleSpace(); // Pushes the label to the center
-                GUILayout.EndHorizontal();
-                GUILayout.Space(8);
-            }
-            else
-            {
-                bannerIcon = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath("6ee731e02404e154694005c2442f2bf4"), typeof(Texture)) as Texture;
-            }
-
-
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace(); // Pushes the label to the center
+            GUILayout.Label(bannerIcon, GUILayout.Height(42), GUILayout.Width(168));
+            GUILayout.FlexibleSpace(); // Pushes the label to the center
+            GUILayout.EndHorizontal();
+            GUILayout.Space(8);
+            
             GUILayout.BeginHorizontal(GUI.skin.box);
             GUILayout.Label("BlendShapes Extracting Tool by Triturbo", EditorStyles.boldLabel);
             GUILayout.EndHorizontal();
 
             EditorGUILayout.Separator();
-
-
+            
             EditorGUI.BeginChangeCheck();
-
-
             EditorGUI.BeginChangeCheck();
             originFBX = (GameObject)EditorGUILayout.ObjectField("Origin FBX", originFBX, typeof(GameObject), false);
             if (EditorGUI.EndChangeCheck() && originFBX != null)
             {
                 originIsFbx = IsFBXFile(originFBX);
             }
-
             if (!originIsFbx && originFBX != null)
             {
                 EditorGUILayout.HelpBox("This is not an fbx file", MessageType.Error);
@@ -277,7 +262,7 @@ namespace Triturbo.BlendShapeShare.Extractor
                 Transform correspondingTransform = origin.transform.Find(relativePath);
                 if (correspondingTransform == null)
                 {
-                    Debug.LogError($"Cannot find corresponding GameObject for {meshRenderer.name} in origin: {origin.name}");
+                    Debug.LogWarning($"Cannot find corresponding GameObject for {meshRenderer.name} in origin: {origin.name}");
                     continue;
                 }
 
@@ -310,57 +295,6 @@ namespace Triturbo.BlendShapeShare.Extractor
 
             return meshDataList;
         }
-         
-        // public void InitBlendShapesToggles()
-        // {
-        //     if (sourceFBX == null) return;
-        //     skinnedMeshRenderers = new List<SkinnedMeshRenderer>(sourceFBX.GetComponentsInChildren<SkinnedMeshRenderer>());
-        //
-        //     foreach (var skinnedMeshRenderer in skinnedMeshRenderers)
-        //     {
-        //         Mesh mesh = skinnedMeshRenderer.sharedMesh;
-        //         if (mesh == null) continue;
-        //
-        //
-        //         int blendShapeCount = mesh.blendShapeCount;
-        //         if (blendShapeCount == 0) continue;
-        //
-        //         if (!blendShapeToggles.ContainsKey(skinnedMeshRenderer))
-        //         {
-        //             blendShapeToggles[skinnedMeshRenderer] = new bool[blendShapeCount];
-        //            
-        //
-        //             if (originFBX == null)
-        //             {
-        //                 continue;
-        //
-        //             }
-        //             Mesh originMesh = originFBX.transform.Find(skinnedMeshRenderer.name)?.GetComponent<SkinnedMeshRenderer>()?.sharedMesh;
-        //
-        //             if (originMesh == null)
-        //             {
-        //                 Debug.LogError($"Can not find {skinnedMeshRenderer.name} in origin: {originFBX.name}");
-        //                 continue;
-        //             }
-        //
-        //
-        //
-        //             for (int i = 0; i < blendShapeCount; i++)
-        //             {
-        //                 string shapeName = mesh.GetBlendShapeName(i);
-        //                 if (originMesh.GetBlendShapeIndex(shapeName) == -1)
-        //                 {
-        //                     blendShapeToggles[skinnedMeshRenderer][i] = true;
-        //                 }
-        //             }
-        //
-        //         }
-        //
-        //
-        //
-        //
-        //     }
-        // }
         private void InitBlendShapesToggles()
         {
             if (sourceFBX == null) return;

--- a/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractorEditor.cs.meta
+++ b/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractorEditor.cs.meta
@@ -3,7 +3,12 @@ guid: a366639a5917c0c479e5357ea16074a5
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - m_ViewDataDictionary: {instanceID: 0}
+  - originFBX: {instanceID: 0}
+  - sourceFBX: {instanceID: 0}
+  - bannerIcon: {fileID: 2800000, guid: 6ee731e02404e154694005c2442f2bf4, type: 3}
+  - currentFocus: {instanceID: 0}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/Packages/com.triturbo.blendshare/Editor/Util.meta
+++ b/Packages/com.triturbo.blendshare/Editor/Util.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4343826da070ba343aeaa10ae8e6f6db
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.triturbo.blendshare/Editor/Util/FbxUtil.cs
+++ b/Packages/com.triturbo.blendshare/Editor/Util/FbxUtil.cs
@@ -1,0 +1,68 @@
+#if ENABLE_FBX_SDK
+using Autodesk.Fbx;
+
+namespace Triturbo.BlendShapeShare.Util.Fbx
+{
+    public static class FbxUtil
+    {
+        private static FbxNode FindChildByPath(this FbxNode rootNode, string path)
+        {
+            if (rootNode == null || string.IsNullOrEmpty(path))
+            {
+                return rootNode;
+            }
+
+            string[] parts = path.Split('/');
+            FbxNode currentNode = rootNode;
+            foreach (string part in parts)
+            {
+                bool found = false;
+                for (int i = 0; i < currentNode.GetChildCount(); i++)
+                {
+                    FbxNode child = currentNode.GetChild(i);
+                    if (child.GetName() == part)
+                    {
+                        currentNode = child;
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    for (int i = 0; i < currentNode.GetChildCount(); i++)
+                    {
+                        FbxNode child = currentNode.GetChild(i);
+                    }
+                    return null; // Node not found in hierarchy
+                }
+            }
+            return currentNode;
+        }
+        
+        public static FbxNode FindMeshChild(this FbxNode rootNode, string name)
+        {
+            if (rootNode.GetName() == name && rootNode.GetMesh() != null)
+            { 
+                return rootNode;
+            }
+            
+            for (int i = 0; i < rootNode.GetChildCount(); i++)
+            {
+                FbxNode child = rootNode.GetChild(i);
+                if (child.GetName() == name && child.GetMesh() != null)
+                { 
+                    return child;
+                }
+            }
+
+            for (int i = 0; i < rootNode.GetChildCount(); i++)
+            {
+                return rootNode.GetChild(i).FindMeshChild(name);
+            }
+            
+            return null;
+        }
+    }
+}
+
+#endif

--- a/Packages/com.triturbo.blendshare/Editor/Util/FbxUtil.cs.meta
+++ b/Packages/com.triturbo.blendshare/Editor/Util/FbxUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b0783dbbf3f20544b9950cddcd712f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.triturbo.blendshare/Editor/Util/Triturbo.BlendShapeShare.Util.asmdef
+++ b/Packages/com.triturbo.blendshare/Editor/Util/Triturbo.BlendShapeShare.Util.asmdef
@@ -1,10 +1,8 @@
 {
-    "name": "Triturbo.BlendShapeShare.Extractor.Editor",
+    "name": "Triturbo.BlendShapeShare.Extractor.Util",
     "rootNamespace": "",
     "references": [
-        "GUID:2b82e46c4ca0a4eb697ab8ccdfb39af1",
-        "GUID:36c306fbfd17b8a4a8443f67f3991996",
-        "GUID:310e50e946a3d3f47a2b344b62f35a08"
+        "GUID:2b82e46c4ca0a4eb697ab8ccdfb39af1"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/com.triturbo.blendshare/Editor/Util/Triturbo.BlendShapeShare.Util.asmdef.meta
+++ b/Packages/com.triturbo.blendshare/Editor/Util/Triturbo.BlendShapeShare.Util.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 310e50e946a3d3f47a2b344b62f35a08
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.triturbo.blendshare/package.json
+++ b/Packages/com.triturbo.blendshare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.triturbo.blendshare",
   "displayName": "BlendShare",
-  "version": "0.0.10",
+  "version": "0.0.11-dev",
   "description": "BlendShare is a tool designed for creators who need to share blendshapes without distributing the original FBX files.",
   "gitDependencies": {},
   "vpmDependencies": {},

--- a/Packages/com.triturbo.blendshare/package.json
+++ b/Packages/com.triturbo.blendshare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.triturbo.blendshare",
   "displayName": "BlendShare",
-  "version": "0.0.11-dev",
+  "version": "0.0.11",
   "description": "BlendShare is a tool designed for creators who need to share blendshapes without distributing the original FBX files.",
   "gitDependencies": {},
   "vpmDependencies": {},


### PR DESCRIPTION
## Summary
This PR fixes an issue where nested FBX nodes could not be found or extract blendshapes, introduces an Apply Transform option to fix mesh orientation differences.
Changed BlendShare version to `0.0.11`

## Changes
- Fix: Resolve nested FBX node issue.
- Feat: Add Apply Transform option for FBX models with different rotations.
  - Some FBX models toggle Apply Transform in Blender exporter, causing different orientations after export.
  - Apply Transform: Apply Rotation ensures all object rotation is applied during calculating blendshape differences.
- Fix: Prevent index out of range in vertices welding.