### PR TITLE
Implement vertex weights & colors

### DIFF
--- a/Packages/com.triturbo.blendshare/Editor/BlendShapeData/BlendShapeAppender.cs
+++ b/Packages/com.triturbo.blendshare/Editor/BlendShapeData/BlendShapeAppender.cs
@@ -168,6 +168,30 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
                     frame.AddBlendShapeFrame(ref newMesh, blendShapeData.m_ShapeName);
                 }
             }
+
+            // Apply skinning data if available
+            if (meshBlendShapesData.HasSkinningData)
+            {
+                if (newMesh.vertexCount == meshBlendShapesData.m_BoneWeights.Length)
+                {
+                    newMesh.boneWeights = meshBlendShapesData.m_BoneWeights;
+                    newMesh.bindposes = meshBlendShapesData.m_BindPoses;
+                }
+                else
+                {
+                    Debug.LogWarning($"[BlendShare] Skipping weight application for {meshBlendShapesData.m_MeshName} due to vertex count mismatch.");
+                }
+            }
+
+            // Apply vertex colors if available
+            if (meshBlendShapesData.HasVertexColors)
+            {
+                if (newMesh.vertexCount == meshBlendShapesData.m_Colors.Length)
+                {
+                    newMesh.colors = meshBlendShapesData.m_Colors;
+                }
+            }
+            
             return newMesh;
         }
         public static bool IsAllMeshesValid(IEnumerable<BlendShapeDataSO> blendShapes, IEnumerable<Mesh> meshes)

--- a/Packages/com.triturbo.blendshare/Editor/BlendShapeData/Inspector/BlendShapeDataSOEditor.cs
+++ b/Packages/com.triturbo.blendshare/Editor/BlendShapeData/Inspector/BlendShapeDataSOEditor.cs
@@ -232,7 +232,7 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
 #if !ENABLE_FBX_SDK
                     if (generated == null)
                     {
-                        EditorUtility.DisplayDialog("Unity mesh vertices not match", "Unable to create mesh since vertices not match. Please import FBX SDK and create FBX file", "OK")
+                        EditorUtility.DisplayDialog("Unity mesh vertices not match", "Unable to create mesh since vertices not match. Please import FBX SDK and create FBX file", "OK");
                     }
 #endif
                 }

--- a/Packages/com.triturbo.blendshare/Editor/BlendShapeData/ScriptableObject/BlendShapeDataSO.cs
+++ b/Packages/com.triturbo.blendshare/Editor/BlendShapeData/ScriptableObject/BlendShapeDataSO.cs
@@ -75,6 +75,14 @@ namespace Triturbo.BlendShapeShare.BlendShapeData
         public string m_MeshName;
         public List<string> m_ShapeNames;
 
+        public BoneWeight[] m_BoneWeights;
+        public Matrix4x4[] m_BindPoses;
+        public string[] m_BoneNames;
+        public Color[] m_Colors;
+
+        public bool HasSkinningData => m_BoneWeights != null && m_BoneWeights.Length > 0;
+        public bool HasVertexColors => m_Colors != null && m_Colors.Length > 0;
+
         [SerializeField]
         private List<BlendShapeWrapper> m_BlendShapes;
         public List<BlendShapeWrapper> BlendShapes

--- a/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractor.cs
+++ b/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractor.cs
@@ -328,6 +328,13 @@ namespace Triturbo.BlendShapeShare.Extractor
                         meshData.SetBlendShape(name, GetFbxBlendShapeData(channel, sourceMesh, weldingGroups, relativeTransform, baseMesh));
                     }
                 }
+
+                // Extract Skinning Data via FBX SDK
+                if (!meshData.HasSkinningData && sourceMesh.GetDeformerCount(FbxDeformer.EDeformerType.eSkin) > 0)
+                {
+                    meshData.ExtractFbxSkin(sourceMesh, weldingGroups, relativeTransform, baseMesh);
+                }
+
                 relativeTransform.Dispose();
             }
             
@@ -654,6 +661,98 @@ namespace Triturbo.BlendShapeShare.Extractor
         }
 
 
+        internal static void ExtractFbxSkin(this MeshData meshData, FbxMesh sourceMesh, List<List<int>> weldingGroups, FbxAMatrix transformMatrix, FbxMesh baseMesh = null)
+        {
+            int controlPointCount = sourceMesh.GetControlPointsCount();
+            var skin = (FbxSkin)sourceMesh.GetDeformer(0, FbxDeformer.EDeformerType.eSkin);
+            if (skin == null) return;
+
+            // In com.autodesk.fbx 4.2.1, FbxSkin might not expose GetClusterCount directly.
+            // We use GetSrcObjectCount with manual iteration to find clusters.
+            int clusterCount = 0;
+            for (int i = 0; i < skin.GetSrcObjectCount(); i++)
+            {
+                if (skin.GetSrcObject(i) is FbxCluster) clusterCount++;
+            }
+
+            meshData.m_BoneNames = new string[clusterCount];
+            meshData.m_BindPoses = new Matrix4x4[clusterCount];
+            
+            var boneWeights = new BoneWeight[controlPointCount];
+            var weightCounts = new int[controlPointCount];
+
+            int validClusterIndex = 0;
+            for (int i = 0; i < skin.GetSrcObjectCount(); i++)
+            {
+                FbxObject srcObj = skin.GetSrcObject(i);
+                FbxCluster cluster = srcObj as FbxCluster;
+                if (cluster == null) continue;
+
+                meshData.m_BoneNames[validClusterIndex] = cluster.GetLink() != null ? cluster.GetLink().GetName() : "Unknown Bone";
+
+                // Bind Pose
+                FbxAMatrix linkMatrix = new FbxAMatrix();
+                cluster.GetTransformLinkMatrix(linkMatrix);
+                meshData.m_BindPoses[validClusterIndex] = linkMatrix.Inverse().ToUnityMatrix();
+
+                // Weights
+                int clusterIndexCount = cluster.GetControlPointIndicesCount();
+                
+                for (int j = 0; j < clusterIndexCount; j++)
+                {
+                    // Use index-based accessors which are more stable in Unity's wrapper
+                    int vertexIndex = cluster.GetControlPointIndexAt(j);
+                    float weightValue = (float)cluster.GetControlPointWeightAt(j);
+
+                    if (vertexIndex < 0 || vertexIndex >= controlPointCount) continue;
+
+                    var bw = boneWeights[vertexIndex];
+                    int count = weightCounts[vertexIndex]++;
+
+                    switch (count)
+                    {
+                        case 0: bw.boneIndex0 = validClusterIndex; bw.weight0 = weightValue; break;
+                        case 1: bw.boneIndex1 = validClusterIndex; bw.weight1 = weightValue; break;
+                        case 2: bw.boneIndex2 = validClusterIndex; bw.weight2 = weightValue; break;
+                        case 3: bw.boneIndex3 = validClusterIndex; bw.weight3 = weightValue; break;
+                    }
+                    boneWeights[vertexIndex] = bw;
+                }
+                validClusterIndex++;
+            }
+            
+            // Normalize weights
+            for (int i = 0; i < controlPointCount; i++)
+            {
+                var bw = boneWeights[i];
+                float total = bw.weight0 + bw.weight1 + bw.weight2 + bw.weight3;
+                if (total > 0)
+                {
+                    bw.weight0 /= total;
+                    bw.weight1 /= total;
+                    bw.weight2 /= total;
+                    bw.weight3 /= total;
+                }
+                boneWeights[i] = bw;
+            }
+
+            meshData.m_BoneWeights = boneWeights;
+        }
+
+        // Helper to convert FBX matrix to Unity matrix
+        private static Matrix4x4 ToUnityMatrix(this FbxAMatrix fbxMat)
+        {
+            Matrix4x4 unityMat = new Matrix4x4();
+            for (int r = 0; r < 4; r++)
+            {
+                for (int c = 0; c < 4; c++)
+                {
+                    unityMat[r, c] = (float)fbxMat.Get(r, c);
+                }
+            }
+            return unityMat;
+        }
+
 #endif
 
         #endregion
@@ -787,6 +886,12 @@ namespace Triturbo.BlendShapeShare.Extractor
                 }
 
                 meshData.ExtractUnityBlendShapes(sourceMesh, baseMesh);
+                
+                // Extract bone names from SkinnedMeshRenderer
+                if (meshRenderer != null && meshRenderer.bones != null)
+                {
+                    meshData.m_BoneNames = meshRenderer.bones.Select(b => b.name).ToArray();
+                }
             }
 
             stopwatch.Stop();
@@ -878,6 +983,21 @@ namespace Triturbo.BlendShapeShare.Extractor
                 meshData.SetBlendShape(shapeName, unityBlendShapeData);
             }
 
+            // Extract skinning data if not already present
+            if (!meshData.HasSkinningData && sourceMesh.bindposes != null && sourceMesh.bindposes.Length > 0)
+            {
+                meshData.m_BoneWeights = sourceMesh.boneWeights;
+                meshData.m_BindPoses = sourceMesh.bindposes;
+                
+                // Try to get bone names if possible (requires finding the SMR)
+                // This is a bit tricky from just the Mesh, but the caller often has the GameObject
+            }
+
+            // Extract vertex colors
+            if (sourceMesh.colors != null && sourceMesh.colors.Length > 0)
+            {
+                meshData.m_Colors = sourceMesh.colors;
+            }
         }
 
         #endregion

--- a/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractorEditor.cs
+++ b/Packages/com.triturbo.blendshare/Editor/Extractor/BlendShapesExtractorEditor.cs
@@ -35,6 +35,9 @@ namespace Triturbo.BlendShapeShare.Extractor
 
         public bool weldVertices = true;
 
+        public bool includeWeights = true;
+        public bool includeColors = true;
+
         // blendshapes togles
         public Vector2 mainScrollPos;
         private List<SkinnedMeshRenderer> skinnedMeshRenderers;
@@ -143,6 +146,9 @@ namespace Triturbo.BlendShapeShare.Extractor
                 EditorGUI.indentLevel--;
             }
 
+            includeWeights = EditorGUILayout.Toggle(Localization.G("extractor.include_weights"), includeWeights);
+            includeColors = EditorGUILayout.Toggle(Localization.G("extractor.include_colors"), includeColors);
+
             baseMesh = Localization.LocalizedEnumPopup(Localization.G("extractor.base_mesh"), baseMesh,
                 "extractor.enum.base_mesh");
             
@@ -184,6 +190,8 @@ namespace Triturbo.BlendShapeShare.Extractor
                     applyRotation = applyRotation,
                     applyScale = applyScale,
                     applyTranslate = applyTranslate,
+                    includeWeights = includeWeights,
+                    includeColors = includeColors,
                 };
 
                 BlendShapeDataSO so = BlendShapesExtractor.ExtractBlendShapes(sourceFBX, originFBX, meshDataList, blendShapesExtractorOptions);

--- a/Packages/com.triturbo.blendshare/Editor/Localization/en-US.json
+++ b/Packages/com.triturbo.blendshare/Editor/Localization/en-US.json
@@ -2,16 +2,13 @@
   "lang": "Language",
   "origin_fbx": "Original FBX",
   "origin_fbx.tooltip": "The unmodified original FBX file.",
-
   "not_an_fbx_error": "This is not an fbx file",
   "source_fbx": "Source FBX",
   "source_fbx.tooltip": "FBX file used as the source for BlendShapes.",
   "blendshapes": "BlendShapes",
-
-  
   "extractor.file_unit_warning": "FBX file units not same, may cause problem\nOriginal: {0}\nSource: {1}",
   "extractor.default_asset_name": "Default Asset Name",
-  "extractor.deformer_id":"Deformer ID",
+  "extractor.deformer_id": "Deformer ID",
   "extractor.weld_vertices": "Weld BlendShape Vertices",
   "extractor.weld_vertices.tooltip": "The BlendShape offset of vertices that will be combined by the Unity model importer will be set to the same value, ensuring that vertices remains consistent with the original mesh.",
   "extractor.apply_transform": "Apply Transform",
@@ -23,7 +20,10 @@
   "extractor.base_mesh.tooltip": "Base mesh for calculating BlendShapes offset vertices",
   "extractor.enum.base_mesh.source": "Source",
   "extractor.enum.base_mesh.original": "Original",
-
+  "extractor.include_weights": "Include Weights",
+  "extractor.include_weights.tooltip": "If enabled, vertex bone weights and bind poses will be extracted.",
+  "extractor.include_colors": "Include Vertex Colors",
+  "extractor.include_colors.tooltip": "If enabled, vertex color data will be extracted.",
   "extractor.compare_method": "Compare Method",
   "extractor.enum.compare_method.name": "Name",
   "extractor.enum.compare_method.name.tooltip": "Compare by name. If there are new blendshapes in the Source FBX, BlendShare will extract them.",
@@ -31,54 +31,39 @@
   "extractor.enum.compare_method.index.tooltip": "Compare by index. If there are more blendshapes than the Original FBX, BlendShare will extract blendshapes from the tail end.",
   "extractor.enum.compare_method.custom": "Custom",
   "extractor.enum.compare_method.custom.tooltip": "Toggle which blendshapes should be extracted individually.",
-
-
-
   "data.original_fbx": "Original FBX",
   "data.original_fbx.tooltip": "Original FBX GameObject asset used to generate meshes.",
-
   "data.apply_blendshapes": "Apply BlendShapes",
   "data.apply_blendshapes.tooltip": "Add BlendShapes in the list to Original FBX.",
   "data.apply_blendshapes.tooltip_locked_message": "\n(Currently this button is disable since you are already apply BlendShapes to Fbx. Click Edit to force enable",
-
   "data.apply_blendshapes_as_new_fbx": "Apply BlendShapes as new FBX",
   "data.apply_blendshapes_as_new_fbx.tooltip": "Duplicate Original FBX and apply BlendShapes to the copy.",
   "data.remove_blendshapes": "Remove BlendShapes",
   "data.remove_blendshapes.tooltip": "Remove BlendShapes in the list from Origin FBX.",
   "data.remove_blendshapes.tooltip_locked_message": "\n(Currently this button is disable since you are not apply BlendShapes to Fbx yet. Click Edit to force enable)",
-
   "data.hidden_settings": "Hidden Settings",
   "data.hidden_settings.default_asset_name": "Default Asset Name",
   "data.hidden_settings.default_asset_name.tooltip": "Default name for generated asset.",
   "data.hidden_settings.applied": "Applied",
   "data.hidden_settings.applied.tooltip": "Indicate if user has applied BlendShapes to FBX.",
   "data.hidden_settings.deformer_id": "Deformer ID",
-
-  
   "data.create_meshes": "Create Meshes",
   "data.create_meshes.tooltip": "Create new mesh assets with BlendShapes.",
   "data.open_advanced_generator": "Open Advanced BlendShape Generator",
   "data.open_advanced_generator.tooltip": "Open the Advanced BlendShape Generator to create a new mesh that combines BlendShapes from multiple BlendShape data assets.",
-
-
   "data.reset_blendshapes": "Reset BlendShapes",
   "data.reset_blendshapes.tooltip": "Reset BlendShapes list to original",
   "data.edit": " Edit ",
   "data.lock": "Lock",
-
-
   "data.dialog.ok": "OK",
   "data.dialog.yes": "Yes",
   "data.dialog.cancel": "Cancel",
   "data.dialog.fbx_missing.title": "Original FBX is missing.",
   "data.dialog.fbx_missing.message": "The original FBX file is missing. Please import the asset or assign an FBX to 'Original FBX'.",
-  
   "data.dialog.apply_blendshapes.title": "Apply BlendShapes",
   "data.dialog.apply_blendshapes.message": "This will add the listed BlendShapes to the original GameObject. Continue?",
   "data.dialog.remove_blendshapes.title": "Remove BlendShapes",
   "data.dialog.remove_blendshapes.message": "This will remove the listed BlendShapes from the original GameObject. Continue?",
-  
-  
   "mesh_asset.applied_blendshapes": "Applied BlendShapes",
   "mesh_asset.read_only": "Fields are read-only. Press 'Edit' to modify metadata.",
   "mesh_asset.assign_meshes": "Assign Meshes",
@@ -89,8 +74,6 @@
   "mesh_asset.assign_meshes.dialog.is_fbx.title": "FBX Asset Selected",
   "mesh_asset.assign_meshes.dialog.is_fbx.message": "The selected object is an FBX asset.\nFBX assets are read-only and cannot be edited directly.\nPlease instantiate the FBX in the scene to make modifications.",
   "mesh_asset.fbx_edited": "The FBX asset has been modified since these meshes were generated.\nChanges to the FBX might cause unexpected results when regenerating or applying new blend shapes.",
-
-
   "mesh_generator.target_mesh_container": "Target Mesh Container",
   "mesh_generator.target_mesh_container.tooltip": "Reference base model to which BlendShapes will be added. The asset can be an FBX model, a mesh asset generated by BlendShare, or an Unity mesh.",
   "mesh_generator.mesh_generation_disable": "This asset cannot be used to generate a mesh asset because the vertex order is incorrect. Please use an FBX file instead.",
@@ -98,10 +81,6 @@
   "mesh_generator.blendshapes_data_list.tooltip": "All listed BlendShapes will be merged and applied to a single model.",
   "mesh_generator.generate_mesh": "Generate new Mesh Asset",
   "mesh_generator.generate_fbx": "Generate new FBX Asset",
-
-
-
-
   "updater.update_check_failed": "Failed to check update:\n{0}",
   "updater.release_parse_failed": "Could not parse GitHub release info.",
   "updater.latest_version": "You already have the latest version ({0}).",
@@ -113,6 +92,4 @@
   "updater.dialog_yes_update": "Yes, Update",
   "updater.dialog_cancel": "Cancel",
   "updater.dialog_view_release": "View Release"
-
-  
 }


### PR DESCRIPTION
I have implemented vertex weight and vertex color transfer. This allows assets to be distributed and used to adapt clothes to varying skeletons.

### Extraction Flow
 `MeshData` includes:
- `m_BoneWeights`: Per-vertex skinning weights.
- `m_BindPoses`: Transformation matrices for bones in the T-pose.
- `m_BoneNames`: Identifying strings used to map weights to target skeletons.
- `m_Colors`: Per-vertex color data for shader masking.

### Extraction Logic [BlendShapesExtractor.cs]
- **Unity Extraction**: Captures weights and colors directly from `SkinnedMeshRenderer` components.
- **FBX SDK Extraction**: Implemented a secondary high-precision pipeline to extract `FbxSkin` and `FbxCluster` data directly from source FBX files on disk. 
    - *Note*: Uses `GetSrcObject` iteration and index-based accessors (`GetControlPointIndexAt`) for maximum compatibility across Unity FBX SDK versions.
    
### Application Logic [BlendShapeAppender.cs]
- Updated the mesh generation pipeline to apply stored bone weights, bind poses, and colors to the newly created persistent mesh assets.

Note that weights are transferred entirely than specific Blendshape weights as this is not feasible. Isolating weights only to vertices moved by a blendshape is not feasible because:
1. **Coherence**: Even when a blendshape is inactive, the vertices need weights to move with the body.
2. **Skeletal Consistency**: If only "blendshape vertices" were weighted, those parts of the clothes would follow the bones while the rest of the shirt would stay frozen at 0,0,0.

This should now allow transfers of rig data stored in Blendshapes so additional blendshapes with weights can be included. This still requires some extensive testing which I plan to do to be sure it works fully as expected.