### PR TITLE
fix(website): pin Fluent UI web components

### DIFF
--- a/Website/app.js
+++ b/Website/app.js
@@ -1,4 +1,4 @@
-import { baseLayerLuminance, StandardLuminance } from 'https://unpkg.com/@fluentui/web-components';
+import { baseLayerLuminance, StandardLuminance } from 'https://unpkg.com/@fluentui/web-components@2.6.1';
 
 const LISTING_URL = "{{ listingInfo.Url }}";
 

--- a/Website/index.html
+++ b/Website/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>VCC Listing</title>
-  <script type="module" src="https://unpkg.com/@fluentui/web-components"></script>
+  <script type="module" src="https://unpkg.com/@fluentui/web-components@2.6.1"></script>
   <link rel="stylesheet" href="styles.css">
   <link rel="icon" href="./favicon.ico">
 </head>


### PR DESCRIPTION
## Summary
- Pin the VPM website Fluent UI CDN imports to @fluentui/web-components@2.6.1
- Avoid accidentally loading Fluent UI 3.x, which breaks the current VPM listing template

## Verification
- git diff --check
- rg --pcre2 "https://unpkg.com/@fluentui/web-components(?!@2\.6\.1)" Website
- rg "https://unpkg.com/@fluentui/web-components@2\.6\.1" Website